### PR TITLE
deployment updates

### DIFF
--- a/ansible/hosts/production
+++ b/ansible/hosts/production
@@ -5,4 +5,4 @@
 digital_ocean
 
 [warpspeed]
-; digital_ocean ansible_ssh_user=warpspeed
+; digital_ocean ansible_user=warpspeed

--- a/ansible/playbooks/production/add-user.yml
+++ b/ansible/playbooks/production/add-user.yml
@@ -1,0 +1,82 @@
+---
+- name: Add Admin User To Production Server
+  hosts: production
+  remote_user: "{{ console_user }}"
+
+  vars_prompt:
+    - name: ansible_sudo_pass
+      prompt: Sudo Password
+      private: yes
+    - name:    new_user_name
+      prompt:  New User Name
+      private: no
+      confirm: no
+    - name: new_user_pass
+      prompt: New User Password
+      private: yes
+      confirm: yes
+    - name: ssh_public_key_file
+      prompt: SSH Public Key File Path
+      private: no
+
+  vars:
+    console_user: "{{ lookup('env', 'USER') }}"
+
+  pre_tasks:
+    - name: Stat SSH Key File
+      register: sshkeyfile
+      delegate_to: 127.0.0.1
+      stat:
+        path: "{{ ssh_public_key_file }}"
+    - name: Make Sure SSH Key File Exists
+      assert:
+        that: sshkeyfile.stat.exists
+        msg:  "File not found: {{ ssh_public_key_file }}"
+
+  tasks:
+    - name: Create User Account
+      become: true
+      user:
+        name:     "{{ new_user_name }}"
+        password: "{{ new_user_pass | password_hash('sha512') }}"
+        shell:    /bin/bash
+        state:    present
+        groups:   www-data
+        append:   yes
+
+    - name: Add User to Sudoers
+      become: true
+      lineinfile:
+        dest:     /etc/sudoers
+        line:     "{{ new_user_name }} ALL=(ALL) ALL"
+        state:    present
+        validate: "visudo -cf %s"
+      tags:
+        - sudoer
+
+    - name: Allow Passwordless Nginx Reload
+      become: true
+      lineinfile:
+        dest:     /etc/sudoers
+        line:     "{{ new_user_name }} ALL=NOPASSWD: /usr/sbin/service nginx reload"
+        state:    present
+        validate: "visudo -cf %s"
+      tags:
+        - sudoer
+
+    - name: Copy Public Key to authorized_keys
+      become: true
+      authorized_key:
+        user: "{{ new_user_name }}"
+        key:  "{{ lookup('file', ssh_public_key_file) }}"
+
+    - name: Allow Login in Sshd Config
+      become: true
+      lineinfile:
+        dest:  /etc/ssh/sshd_config
+        state: present
+        line:  "AllowUsers {{ new_user_name }}"
+
+    - name: Restart SSH
+      service: name=ssh state=restarted
+      become: true

--- a/ansible/playbooks/production/site/https.yml
+++ b/ansible/playbooks/production/site/https.yml
@@ -1,0 +1,64 @@
+---
+- name: Setup HTTPS For A Site
+  hosts: production
+  remote_user: "{{ console_user }}"
+
+  vars_prompt:
+    - name: ansible_sudo_pass
+      prompt: Sudo Password
+      private: yes
+    - name: domain
+      prompt: Domain Name
+      private: no
+    - name: admin_email
+      prompt: Email Address for Notifications
+      private: no
+
+  vars:
+    console_user: "{{ lookup('env', 'USER') }}"
+    enable_https: true
+
+  tasks:
+    - name: Add Certbot Repository
+      apt_repository:
+        repo: 'ppa:certbot/certbot'
+        state: present
+      become: true
+    - name: Install Certbot and Dependencies
+      apt:
+        package: "{{ item }}"
+        state: present
+      become: true
+      with_items:
+        - python-support
+        - python-ndg-httpsclient
+        - certbot
+    - name: Obtain HTTPS Certificate With Certbot
+      become: true
+      shell: "certbot certonly --webroot -w {{ www_home }}/{{ domain }}/public -d {{ domain }} --email {{ admin_email }} --agree-tos --non-interactive"
+
+    - name: Modify Nginx Config - Enable HTTPS
+      blockinfile:
+        dest: "/etc/nginx/sites-available/{{ domain }}"
+        insertafter: "# port to listen on"
+        block: |
+          listen 443 ssl;
+          ssl on;
+          ssl_certificate /etc/letsencrypt/live/{{ domain }}/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;
+          ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # disable SSLv3
+
+    - name: Modify Nginx Config - Redirect HTTP to HTTPS
+      replace:
+        dest: "/etc/nginx/sites-available/{{ domain }}"
+        regexp: "{{ item.re }}"
+        replace: "{{ item.replace }}"
+      with_items:
+        - { re: 'server_name\s*www.*', replace: "server_name {{ domain }} www.{{ domain }};" }
+        - { re: '(\s*return 301 )\$scheme(.*)', replace: '\1https\2' }
+
+    - name: Restart Nginx
+      become: true
+      service:
+        name: nginx
+        state: restarted

--- a/ansible/playbooks/production/site/https.yml
+++ b/ansible/playbooks/production/site/https.yml
@@ -62,3 +62,18 @@
       service:
         name: nginx
         state: restarted
+        
+    - name: Setup Automated Certificate Renewal
+      become: true
+      cron:
+        state: present
+        name: "renew https certs"
+        # let's encrypt asks us to pick a random minute of the hour
+        # see https://certbot.eff.org/all-instructions/
+        job: "sleep $((${RANDOM} % 60))m; /usr/bin/certbot renew"
+        minute: 0
+        hour: 0
+        day: "*"
+        weekday: "*"
+        month: "*"
+

--- a/ansible/playbooks/production/site/php.yml
+++ b/ansible/playbooks/production/site/php.yml
@@ -1,6 +1,7 @@
 ---
 - name: Create Dynamic PHP Site
   hosts: production
+  remote_user: "{{ lookup('env', 'USER') }}"
 
   vars:
     dynamic_php: yes

--- a/ansible/playbooks/production/site/static.yml
+++ b/ansible/playbooks/production/site/static.yml
@@ -1,6 +1,7 @@
 ---
 - name: Create Static PHP Site
   hosts: production
+  remote_user: "{{ lookup('env', 'USER') }}"
 
   vars:
     dynamic_php: no

--- a/ansible/roles/Common/tasks/bash-profile.yml
+++ b/ansible/roles/Common/tasks/bash-profile.yml
@@ -5,14 +5,14 @@
 
 - name: Turn On Color Prompt
   lineinfile:
-    dest: "/home/{{ console_user | default(ansible_ssh_user) }}/.bashrc"
+    dest: "/home/{{ console_user | default(ansible_user) }}/.bashrc"
     line: "force_color_prompt=yes"
     regexp: '#?force_color_prompt=yes'
     state: present
 
 - name: More User Friendly List Aliases
   lineinfile:
-    dest: "/home/{{ console_user | default(ansible_ssh_user) }}/.bashrc"
+    dest: "/home/{{ console_user | default(ansible_user) }}/.bashrc"
     line: "alias {{ item.alias }}='{{ item.command }}'"
     regexp: "^alias {{ item.alias }}="
     state: present
@@ -23,7 +23,7 @@
 
 - name: Cd to /vagrant on Log In
   lineinfile:
-    dest: "/home/{{ console_user | default(ansible_ssh_user) }}/.bashrc"
+    dest: "/home/{{ console_user | default(ansible_user) }}/.bashrc"
     line: cd /vagrant
     state: present
     insertafter: EOF

--- a/ansible/roles/Deploy/Git/tasks/main.yml
+++ b/ansible/roles/Deploy/Git/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Add Remote to Local Repository
   local_action: >
     command git -C {{ local_sites_dir }}/{{ local_domain }} remote add {{ git_remote }}
-    ssh://{{ ansible_user_id }}@{{ ansible_ssh_host }}{{ git_home }}/{{ production_domain }}.git
+    ssh://{{ ansible_user_id }}@{{ ansible_host }}{{ git_home }}/{{ production_domain }}.git
   register: git_result
   failed_when: 'git_result.rc != 0 and ("remote {{ git_remote }} already exists" not in git_result.stderr)'
   changed_when: git_result.rc == 0

--- a/ansible/roles/Deploy/PHP/tasks/dot-env-php.yml
+++ b/ansible/roles/Deploy/PHP/tasks/dot-env-php.yml
@@ -3,6 +3,6 @@
   copy:
     src:   "{{ local_sites_dir }}/{{ local_domain }}/.env.php"
     dest:  "{{ www_home }}/{{ production_domain }}/.env.php"
-    owner: "{{ ansible_ssh_user }}"
+    owner: "{{ ansible_user }}"
     group: www-data
     mode:  0640

--- a/ansible/roles/Deploy/PHP/tasks/laravel.yml
+++ b/ansible/roles/Deploy/PHP/tasks/laravel.yml
@@ -35,5 +35,5 @@
 - name: Don't forget to seed your database (if necessary)
   debug:
     msg: >
-      ssh {{ ansible_ssh_user }}@{{ ansible_ssh_host }}
+      ssh {{ ansible_user }}@{{ ansible_host }}
       '/usr/bin/php {{ www_home }}/{{ production_domain }}/artisan db:seed --force'

--- a/ansible/roles/Deploy/Ruby/tasks/rails.yml
+++ b/ansible/roles/Deploy/Ruby/tasks/rails.yml
@@ -23,5 +23,5 @@
 - name: Don't forget to seed your database (if necessary)
   debug:
     msg: >
-      ssh {{ ansible_ssh_user }}@{{ ansible_ssh_host }}
+      ssh {{ ansible_user }}@{{ ansible_host }}
       bundle exec rake -f {{ www_home }}/{{ production_domain }}/Rakefile db:seed

--- a/ansible/roles/Git-Hook/tasks/main.yml
+++ b/ansible/roles/Git-Hook/tasks/main.yml
@@ -5,7 +5,7 @@
   file:
     path:  "{{ git_home }}/{{ domain }}.git"
     state: directory
-    owner: "{{ ansible_ssh_user }}"
+    owner: "{{ ansible_user }}"
   become: true
 
 - name: Create Repo for Site
@@ -25,7 +25,7 @@
   debug:
     msg: >
       git remote add {{ git_remote }}
-      ssh://{{ ansible_user_id }}@{{ ansible_ssh_host }}{{ git_home }}/{{ domain }}.git
+      ssh://{{ ansible_user_id }}@{{ ansible_host }}{{ git_home }}/{{ domain }}.git
 
 - name: Push your Repository to Deploy
   debug: msg="git push {{ git_remote }} {{ git_production_branch | default('master') }}"

--- a/ansible/roles/Nginx/tasks/main.yml
+++ b/ansible/roles/Nginx/tasks/main.yml
@@ -32,7 +32,7 @@
   file:
     dest: /etc/nginx/sites-available
     state: directory
-    owner: "{{ ansible_ssh_user }}"
+    owner: "{{ ansible_user }}"
     group: www-data
     mode: 0755
   become: true

--- a/ansible/roles/Nginx/tasks/site.yml
+++ b/ansible/roles/Nginx/tasks/site.yml
@@ -3,7 +3,7 @@
   file:
     path:  "{{ www_home }}/{{ domain }}"
     state: directory
-    owner: "{{ ansible_ssh_user }}"
+    owner: "{{ ansible_user }}"
     group: www-data
     mode:  03755
   register: dir_create_result
@@ -16,7 +16,7 @@
   file:
     path:  "{{ www_home }}/{{ domain }}/public"
     state: directory
-    owner: "{{ ansible_ssh_user }}"
+    owner: "{{ ansible_user }}"
     group: www-data
     mode:  03755
   register: dir_create_result
@@ -29,7 +29,7 @@
   template:
     src:   site.conf.j2
     dest:  /etc/nginx/sites-available/{{ domain }}
-    owner: "{{ ansible_ssh_user }}"
+    owner: "{{ ansible_user }}"
     group: www-data
     mode:  0640
   become: true

--- a/ansible/roles/Nginx/templates/site.conf.j2
+++ b/ansible/roles/Nginx/templates/site.conf.j2
@@ -15,8 +15,12 @@ server {
 }
 
 server {
+
+# BEGIN ANSIBLE MANAGED BLOCK
+  # port to listen on
   listen [::]:80;
   listen 80;
+# END ANSIBLE MANAGED BLOCK
 
   # The host name to respond to
   server_name {{ domain }};
@@ -37,6 +41,11 @@ server {
 {% if app_env == "dev" %}
   autoindex on;
 {% endif %}
+
+  # allow certbot domain verification
+  location ~ /\.well-known/acme-challenge/.* {
+    allow all;
+  }
 
   # Skip access log and not found logging for favicons and robots.txt
   location = /favicon.ico {

--- a/ansible/roles/Node/tasks/main.yml
+++ b/ansible/roles/Node/tasks/main.yml
@@ -11,7 +11,7 @@
   become: true
 
 - name: Create NVM Directories
-  file: path={{ nvm_root }}/{{ item }} state=directory owner={{ ansible_ssh_user }} mode=0775
+  file: path={{ nvm_root }}/{{ item }} state=directory owner={{ ansible_user }} mode=0775
   with_items:
     - alias
     - bin

--- a/ansible/roles/Ruby/tasks/main.yml
+++ b/ansible/roles/Ruby/tasks/main.yml
@@ -11,7 +11,7 @@
   file:
     path: "{{ rbenv_root }}"
     state: directory
-    owner: "{{ ansible_ssh_user }}"
+    owner: "{{ ansible_user }}"
     mode: 0755
   become: true
 

--- a/ansible/roles/Warpspeed/Site/tasks/main.yml
+++ b/ansible/roles/Warpspeed/Site/tasks/main.yml
@@ -3,14 +3,14 @@
   command: "{{ ansible_user_dir }}/.warpspeed/bin/warpspeed site:create {{ site_type }} {{ domain }} --force --push"
   environment:
     WARPSPEED_ROOT: "{{ ansible_user_dir }}/.warpspeed"
-    WARPSPEED_USER: "{{ ansible_ssh_user }}"
+    WARPSPEED_USER: "{{ ansible_user }}"
   become: yes
 
 - name: Add the Remote to your Repository
   debug:
     msg: >
       git remote add {{ git_remote }}
-      ssh://{{ ansible_ssh_user }}@{{ ansible_ssh_host }}{{ git_home }}/{{ domain }}.git
+      ssh://{{ ansible_user }}@{{ ansible_host }}{{ git_home }}/{{ domain }}.git
 
 - name: Push your Repository to Deploy
   debug: msg="git push {{ git_remote }} {{ git_production_branch | default('master') }}"


### PR DESCRIPTION
- fix existing deployment functionality

The nginx role was erroring out without `remote_user` being defined 

also

- add a playbook for obtaining an https cert from letsencrypt
- add a playbook for adding another admin user to the prod server

These should probably ultimately be separate roles, but having all the tasks in each playbook works for now.
